### PR TITLE
Fix code scanning alert no. 6: Useless regular-expression character escape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ try {
   // @ts-ignore
   app.ws("/ws", WebSocketHandler(logger));
   for (const ext of params.extensions) {
-    app.get(new RegExp(`^/.+\.${ext}$`), MarkdownHandler(params.template));
+    app.get(new RegExp(`^/.+\\.${ext}$`), MarkdownHandler(params.template));
   }
   app.use(express.static(rootDir, { index: false }));
   app.use(express.static(staticDir, { index: false }));


### PR DESCRIPTION
Fixes [https://github.com/mryhryki/markdown-preview/security/code-scanning/6](https://github.com/mryhryki/markdown-preview/security/code-scanning/6)

To fix the problem, we need to ensure that the escape sequence `\.` is correctly interpreted as a literal dot in the regular expression. This can be achieved by using double backslashes `\\.` in the string literal, which will be correctly interpreted as a single backslash followed by a dot in the regular expression.

- Update the regular expression on line 35 to use double backslashes `\\.` instead of a single backslash `\.`.
- This change will ensure that the regular expression correctly matches file extensions with a literal dot.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
