### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/file_watcher.ts
+++ b/src/lib/file_watcher.ts
@@ -44,6 +44,11 @@ export class FileWatcher {
   }
 
   addTargetFile(filepath: string): void {
+    const absolutePath = path.resolve(rootDir, filepath);
+    if (!absolutePath.startsWith(rootDir)) {
+      this.logger.error("Invalid file path:", filepath);
+      return;
+    }
     if (this._target[filepath] != null) return;
     this.logger.debug("Add watch target:", filepath);
     this._target[filepath] = {
@@ -63,6 +68,9 @@ export class FileWatcher {
 
   getFileInfo(filepath: string): FileChangedEvent {
     const absolutePath = path.resolve(rootDir, filepath);
+    if (!absolutePath.startsWith(rootDir)) {
+      throw new Error("Invalid file path: " + filepath);
+    }
     const markdown = fs.readFileSync(absolutePath, "utf-8");
     return { filepath, markdown };
   }

--- a/src/lib/file_watcher.ts
+++ b/src/lib/file_watcher.ts
@@ -69,7 +69,7 @@ export class FileWatcher {
   getFileInfo(filepath: string): FileChangedEvent {
     const absolutePath = path.resolve(rootDir, filepath);
     if (!absolutePath.startsWith(rootDir)) {
-      throw new Error("Invalid file path: " + filepath);
+      throw new Error(`Invalid file path: ${filepath}`);
     }
     const markdown = fs.readFileSync(absolutePath, "utf-8");
     return { filepath, markdown };


### PR DESCRIPTION
Fixes [https://github.com/mryhryki/markdown-preview/security/code-scanning/4](https://github.com/mryhryki/markdown-preview/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We will:
1. Normalize the path using `path.resolve` to remove any `..` segments.
2. Check that the normalized path starts with the root folder's path.

This will be implemented in the `addTargetFile` method of the `FileWatcher` class, where the `filepath` is first added to the target list. We will also update the `getFileInfo` method to ensure the path is validated before reading the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
