### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -10,6 +10,10 @@ export function MarkdownHandler(template: string) {
       rootDir,
       decodeURIComponent(req.path.substring(1)),
     );
+    if (!filepath.startsWith(rootDir)) {
+      res.status(403).end();
+      return;
+    }
     if (existsFile(filepath)) {
       const templateContent = await fs.readFile(template, "utf-8");
       res.status(200).send(templateContent);


### PR DESCRIPTION
Fixes [https://github.com/mryhryki/markdown-preview/security/code-scanning/2](https://github.com/mryhryki/markdown-preview/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This involves normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. If the path is not within the root folder, we should reject the request.

1. In `src/markdown.ts`, after resolving the `filepath`, we should verify that it starts with `rootDir`.
2. If the `filepath` does not start with `rootDir`, we should return a 403 status code and end the response.
3. This ensures that only files within the `rootDir` can be accessed, preventing path traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
